### PR TITLE
feat: Created Navigation bar

### DIFF
--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -1,10 +1,12 @@
 import React from "react";
+import Navbar from "./Navbar";
 import Banner from "./Banner";
 import Feed from "./Feed";
 
 function Homepage() {
     return (
         <div className="border-box mx-auto w-full h-full md:max-h-screen max-w-screen-3xl">
+            <Navbar />
             <Banner />
             <Feed />
         </div>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+function Navbar() {
+    return (
+        <nav className="mx-auto gap-3 bg-white flex justify-between items-center w-3/4 pl-2 pr-2">
+            <a href="#" className="font-anton text-green-500 tracking-wider text-lg mt-2 mb-2">conduit</a>
+            <ul className="flex gap-1">
+                <li className="p-0.5">
+                    <a href="#" className="font-sans text-gray-400 text-xs no-underline flex items-center p-1">Home</a>
+                </li>
+                <li className="p-0.5">
+                    <a href="#" className="font-sans text-gray-400 text-xs no-underline flex items-center p-1">Sign in</a>
+                </li>
+                <li className="p-0.5">
+                    <a href="#" className="font-sans text-gray-400 text-xs no-underline flex items-center p-1">Sign up</a>
+                </li>
+            </ul>
+        </nav>
+    );
+}
+
+export default Navbar;


### PR DESCRIPTION
Created Navigation bar for the homepage with the text conduit and three links called "Home", "Sign in" and "Sign up". The two attached screenshots show how the navbar looks on a large screen and a small screen. No functionality has been added so far.

<img width="1804" alt="Navbar-large-screen" src="https://user-images.githubusercontent.com/104450960/197872163-3e216b2d-2944-4156-b499-5bdf0e4c3bca.png">
<img width="532" alt="Navbar-small-screen" src="https://user-images.githubusercontent.com/104450960/197872168-8ed21b3c-b4dc-4469-b973-df5066ca6fbc.png">
